### PR TITLE
feat(a11y-checks): run accessibility during development

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "html-webpack-plugin": "^3.2.0",
     "jest": "^23.6.0",
     "react": "^16.6.3",
+    "react-axe": "^3.0.2",
     "react-dom": "^16.6.3",
     "style-loader": "^0.23.1",
     "webpack": "^4.25.1",

--- a/src/index.js
+++ b/src/index.js
@@ -2,4 +2,9 @@ import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
 
+if (process.env.NODE_ENV !== 'production') {
+  var axe = require('react-axe');
+  axe(React, ReactDOM, 1000);
+}
+
 ReactDOM.render(<App />, document.getElementById("root"));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1240,6 +1240,11 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
+axe-core@^3.0.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.1.2.tgz#ca0aff897ebefca7552f97859dc1217c06c4f9e6"
+  integrity sha512-e1WVs0SQu3tM29J9a/mISGvlo2kdCStE+yffIAJF6eb42FS+eUFEVz9j4rgDeV2TAfPJmuOZdRetWYycIbK7Vg==
+
 babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -6224,6 +6229,13 @@ rc@^1.2.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-axe@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/react-axe/-/react-axe-3.0.2.tgz#91e4265b665dd1f45cf3d0254a90c72ff6fd88cb"
+  integrity sha512-cYuxIyOVhZ0kF54V4LMTE33B/ATTzcZtIlU7F7XhP7/gBDWvkxsfjq1oAMLolvI2OhNNivNFEIIJa/rhYj96Pw==
+  dependencies:
+    axe-core "^3.0.0"
 
 react-dom@^16.6.3:
   version "16.6.3"


### PR DESCRIPTION
This PR adds react-axe lib, which inspects the generated markup and checks it for accessibility errors. There are currently none, so you'll see nothing in the console if trying to verify it works. To test, add a button without text to the page and watch the errors appear in the browser's js console.